### PR TITLE
Fixed addIssueLabel function

### DIFF
--- a/src/AppBundle/Issues/StatusApi.php
+++ b/src/AppBundle/Issues/StatusApi.php
@@ -37,15 +37,22 @@ class StatusApi
     public function addIssueLabel($issueNumber, $newLabel)
     {
         $currentLabels = $this->labelsApi->getIssueLabels($issueNumber);
-        foreach ($currentLabels as $label) {
-            if ($label !== $newLabel) {
-                $this->labelsApi->addIssueLabel($issueNumber, $newLabel);
 
-                return true;
+        if (!empty($currentLabels)) {
+            foreach ($currentLabels as $label) {
+                if ($label !== $newLabel) {
+                    $this->labelsApi->addIssueLabel($issueNumber, $newLabel);
+
+                    return true;
+                }
             }
+
+            return false;
         }
 
-        return false;
+        $this->labelsApi->addIssueLabel($issueNumber, $newLabel);
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
Add a label wasn't working if the issue doesn't have at least 1 label: annoying :)