### PR TITLE
Remove useless lines of code

### DIFF
--- a/src/AppBundle/Issues/StatusApi.php
+++ b/src/AppBundle/Issues/StatusApi.php
@@ -36,22 +36,8 @@ class StatusApi
      */
     public function addIssueLabel($issueNumber, $newLabel)
     {
-        $currentLabels = $this->labelsApi->getIssueLabels($issueNumber);
-
-        if (!empty($currentLabels)) {
-            foreach ($currentLabels as $label) {
-                if ($label !== $newLabel) {
-                    if (isset(Labels::ALIASES[$newLabel])) {
-                        $newLabel = Labels::ALIASES[$newLabel];
-                    }
-
-                    $this->labelsApi->addIssueLabel($issueNumber, $newLabel);
-
-                    return true;
-                }
-            }
-
-            return false;
+        if (isset(Labels::ALIASES[$newLabel])) {
+            $newLabel = Labels::ALIASES[$newLabel];
         }
 
         $this->labelsApi->addIssueLabel($issueNumber, $newLabel);

--- a/src/AppBundle/PullRequests/Labels.php
+++ b/src/AppBundle/PullRequests/Labels.php
@@ -21,7 +21,7 @@ final class Labels
 
     const CRITICAL = 'Critical';
 
-    const REFACTONG = 'Need refacto';
+    const REFACTORING = 'Refactoring';
 
     // Help to prevent changes in the future
     const ALIASES = [
@@ -29,6 +29,6 @@ final class Labels
         'critical' => self::CRITICAL,
         'improvement' => self::IMPROVEMENT,
         'new feature' => self::FEATURE,
-        'refacto' => self::REFACTONG,
+        'refacto' => self::REFACTORING,
     ];
 }

--- a/src/AppBundle/PullRequests/Labels.php
+++ b/src/AppBundle/PullRequests/Labels.php
@@ -19,10 +19,16 @@ final class Labels
 
     const IMPROVEMENT = 'Improvement';
 
+    const CRITICAL = 'Critical';
+
+    const REFACTONG = 'Need refacto';
+
     // Help to prevent changes in the future
     const ALIASES = [
-        'new feature' => self::FEATURE,
         'bug fix' => self::BUG,
+        'critical' => self::CRITICAL,
         'improvement' => self::IMPROVEMENT,
+        'new feature' => self::FEATURE,
+        'refacto' => self::REFACTONG,
     ];
 }

--- a/tests/AppBundle/Issues/StatusApiTest.php
+++ b/tests/AppBundle/Issues/StatusApiTest.php
@@ -83,7 +83,7 @@ class StatusApiTest extends TestCase
     {
         $this->labelsApi->expects($this->once())
             ->method('addIssueLabel')
-            ->with(1234, 'Need refacto');
+            ->with(1234, 'Refactoring');
 
         $this->api->addIssueLabel(1234, 'refacto');
     }

--- a/tests/AppBundle/Issues/StatusApiTest.php
+++ b/tests/AppBundle/Issues/StatusApiTest.php
@@ -70,6 +70,24 @@ class StatusApiTest extends TestCase
         $this->api->addIssueLabel(1234, 'improvement');
     }
 
+    public function testAddIssueLabelWithCriticalAlias()
+    {
+        $this->labelsApi->expects($this->once())
+            ->method('addIssueLabel')
+            ->with(1234, 'Critical');
+
+        $this->api->addIssueLabel(1234, 'critical');
+    }
+
+    public function testAddIssueLabelWithRefactoAlias()
+    {
+        $this->labelsApi->expects($this->once())
+            ->method('addIssueLabel')
+            ->with(1234, 'Need refacto');
+
+        $this->api->addIssueLabel(1234, 'refacto');
+    }
+
     public function testGetNeedsReviewUrl()
     {
         $this->assertSame(

--- a/tests/AppBundle/Issues/StatusApiTest.php
+++ b/tests/AppBundle/Issues/StatusApiTest.php
@@ -37,11 +37,6 @@ class StatusApiTest extends TestCase
     public function testAddIssueLabel()
     {
         $this->labelsApi->expects($this->once())
-            ->method('getIssueLabels')
-            ->with(1234)
-            ->willReturn(['Bug', 'Status: Needs Review']);
-
-        $this->labelsApi->expects($this->once())
             ->method('addIssueLabel')
             ->with(1234, 'Code reviewed');
 
@@ -50,11 +45,6 @@ class StatusApiTest extends TestCase
 
     public function testAddIssueLabelWithBugAlias()
     {
-        $this->labelsApi->expects($this->once())
-            ->method('getIssueLabels')
-            ->with(1234)
-            ->willReturn(['Bug', 'Status: Needs Review']);
-
         $this->labelsApi->expects($this->once())
             ->method('addIssueLabel')
             ->with(1234, 'Bug');
@@ -65,11 +55,6 @@ class StatusApiTest extends TestCase
     public function testAddIssueLabelWithFeatureAlias()
     {
         $this->labelsApi->expects($this->once())
-            ->method('getIssueLabels')
-            ->with(1234)
-            ->willReturn(['Feature', 'Status: Needs Review']);
-
-        $this->labelsApi->expects($this->once())
             ->method('addIssueLabel')
             ->with(1234, 'Feature');
 
@@ -78,11 +63,6 @@ class StatusApiTest extends TestCase
 
     public function testAddIssueLabelWithImprovementAlias()
     {
-        $this->labelsApi->expects($this->once())
-            ->method('getIssueLabels')
-            ->with(1234)
-            ->willReturn(['Improvement', 'Status: Needs Review']);
-
         $this->labelsApi->expects($this->once())
             ->method('addIssueLabel')
             ->with(1234, 'Improvement');


### PR DESCRIPTION
No need to retrieve labels to add a new one.
if `getIssueLabels` returns `['Bug', 'Improvement', '1.7.4.x']` and I want to add `Critical` (for example).
At the first iteration `$label` will be different than `$newLabel` so it will add `Critical` and return true. More no alias was added if there is no issue labels. And add Critical / refacto because they are already available in `getValidTypes` assert.