### PR TITLE
Add version number API route

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -5,6 +5,8 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
 {
+    const PRESTON_BOT_VERSION = '3.0.0';
+
     public function registerBundles()
     {
         $bundles = [

--- a/src/AppBundle/Controller/VersionNumberController.php
+++ b/src/AppBundle/Controller/VersionNumberController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace AppBundle\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class VersionNumberController
+{
+    /**
+     * @Route("/version", name="version_number")
+     */
+    public function getVersionNumberAction()
+    {
+        return new JsonResponse(\AppKernel::PRESTON_BOT_VERSION);
+    }
+}


### PR DESCRIPTION
I have doubts about the deployment pipeline for PrestonBot. I think it's broken.

In order to find out, I add the following API endpoint `/version` that will help us make sure whether PrestonBot is up-to-date or not