### PR TITLE
Make relatedTicket mandatory in the PR's description

### DIFF
--- a/app/Resources/views/markdown/pr_table_errors.md.twig
+++ b/app/Resources/views/markdown/pr_table_errors.md.twig
@@ -1,5 +1,5 @@
 <!-- PR_TABLE_DESCRIPTION_ERROR -->
-Hi!
+Hi, thanks for this contribution!
 
 Your pull request description seems to be incomplete or malformed:
 
@@ -7,8 +7,6 @@ Your pull request description seems to be incomplete or malformed:
 * {{ error.message }} 
 {% endfor %}
 
-Would you mind completing the contribution table ? This would help us understand how interesting your contribution is.
-
-Thank you!
+Would you mind completing it? This would help us understand how interesting your contribution is, thank you very much!
 
 (note: this is an automated message, but answering it will reach a real human )

--- a/app/Resources/views/markdown/pr_table_errors.md.twig
+++ b/app/Resources/views/markdown/pr_table_errors.md.twig
@@ -9,4 +9,8 @@ Your pull request description seems to be incomplete or malformed:
 
 Would you mind completing it? This would help us understand how interesting your contribution is, thank you very much!
 
+{% if missingRelatedTicket %}
+Note: it is a good practice to open an issue before submitting a Pull Request as it allows maintainers to verify that the bug is effectively due to a defect in the code (and that it hasn't already been fixed) and to discuss the improvement/feature suggestion before a single line of code is written. Additionally, it may lead the Core Product team to mark that issue as a priority, further attracting the maintainer's attention.
+{% endif %}
+
 (note: this is an automated message, but answering it will reach a real human )

--- a/src/AppBundle/PullRequests/BodyParser.php
+++ b/src/AppBundle/PullRequests/BodyParser.php
@@ -142,7 +142,7 @@ class BodyParser
     }
 
     /**
-     * @Assert\NotBlank(message = "Each pull request should have a ticket linked. Please link it to an existing issue or create a new issue so that it can be reviewed and tested.")
+     * @Assert\NotBlank(message = "Your pull request does not seem to fix any issue, you might consider [creating one](https://github.com/PrestaShop/PrestaShop/issues/new/choose) (see note below).")
      *
      * @return string
      */

--- a/src/AppBundle/PullRequests/BodyParser.php
+++ b/src/AppBundle/PullRequests/BodyParser.php
@@ -148,9 +148,10 @@ class BodyParser
      */
     public function getRelatedTicket()
     {
-        $regex = sprintf(self::DEFAULT_PATTERN, 'Fixed ticket', '?:.*(#[0-9]+)');
+        $regex = sprintf(self::DEFAULT_PATTERN, 'Fixed ticket', '?:.*(?:#|\/issues\/)([0-9]+)');
+        $ticket = $this->extractWithRegex($regex);
 
-        return $this->extractWithRegex($regex);
+        return empty($ticket) ? '' : '#'.$ticket;
     }
 
     /**

--- a/src/AppBundle/PullRequests/BodyParser.php
+++ b/src/AppBundle/PullRequests/BodyParser.php
@@ -46,7 +46,7 @@ class BodyParser
      */
     public function getDescription()
     {
-        $regex = sprintf(self::DEFAULT_PATTERN, 'Description', '.+');
+        $regex = sprintf(self::DEFAULT_PATTERN, 'Description', '[^|]+');
 
         return $this->extractWithRegex($regex);
     }
@@ -142,11 +142,13 @@ class BodyParser
     }
 
     /**
+     * @Assert\NotBlank(message = "Each pull request should have a ticket linked. Please link it to an existing issue or create a new issue so that it can be reviewed and tested.")
+     *
      * @return string
      */
     public function getRelatedTicket()
     {
-        $regex = sprintf(self::DEFAULT_PATTERN, 'Fixed ticket', '.+');
+        $regex = sprintf(self::DEFAULT_PATTERN, 'Fixed ticket', '?:.*(#[0-9]+)');
 
         return $this->extractWithRegex($regex);
     }

--- a/src/AppBundle/PullRequests/Listener.php
+++ b/src/AppBundle/PullRequests/Listener.php
@@ -59,7 +59,7 @@ class Listener
 
         $validationErrors = $this->validator->validate($bodyParser);
         $missingRelatedTicket = empty($bodyParser->getRelatedTicket());
-        if (count($validationErrors) > 0) {
+        if (\count($validationErrors) > 0) {
             $this->commentApi->sendWithTemplate(
                 $pullRequest,
                 'markdown/pr_table_errors.md.twig',
@@ -80,7 +80,7 @@ class Listener
         $bodyParser = new BodyParser($pullRequest->getBody());
 
         $bodyErrors = $this->validator->validate($bodyParser);
-        if (0 === count($bodyErrors)) {
+        if (0 === \count($bodyErrors)) {
             $this->repository->removeCommentsIfExists(
                 $pullRequest,
                 self::TABLE_ERROR,
@@ -105,7 +105,7 @@ class Listener
      */
     public function removeCommitValidationComment(PullRequest $pullRequest)
     {
-        if (0 === count($this->getErrorsFromCommits($pullRequest))) {
+        if (0 === \count($this->getErrorsFromCommits($pullRequest))) {
             $this->repository->removeCommentsIfExists(
                 $pullRequest,
                 self::COMMIT_ERROR,
@@ -133,7 +133,7 @@ class Listener
     {
         $userCommits = $this->commitRepository->findAllByUser($sender);
 
-        if (0 !== count($userCommits)) {
+        if (0 !== \count($userCommits)) {
             return false;
         }
 
@@ -167,7 +167,7 @@ class Listener
             $commitParser = new CommitParser($commitLabel, $pullRequest);
             $validationErrors = $this->validator->validate($commitParser);
 
-            if (count($validationErrors) > 0) {
+            if (\count($validationErrors) > 0) {
                 $commitsErrors[] = $commitLabel;
             }
         }

--- a/src/AppBundle/PullRequests/Listener.php
+++ b/src/AppBundle/PullRequests/Listener.php
@@ -58,11 +58,12 @@ class Listener
         $bodyParser = new BodyParser($pullRequest->getBody());
 
         $validationErrors = $this->validator->validate($bodyParser);
+        $missingRelatedTicket = empty($bodyParser->getRelatedTicket());
         if (count($validationErrors) > 0) {
             $this->commentApi->sendWithTemplate(
                 $pullRequest,
                 'markdown/pr_table_errors.md.twig',
-                ['errors' => $validationErrors]
+                ['errors' => $validationErrors, 'missingRelatedTicket' => $missingRelatedTicket]
             );
 
             $this->logger->info(sprintf('[Invalid Table] Pull request n° %s', $pullRequest->getNumber()));

--- a/tests/AppBundle/PullRequests/BodyParserTest.php
+++ b/tests/AppBundle/PullRequests/BodyParserTest.php
@@ -89,6 +89,12 @@ class BodyParserTest extends TestCase
         $this->assertSame('#1234', $this->bodyParser->getRelatedTicket());
     }
 
+    public function testGetTicketUrl()
+    {
+        $this->bodyParser = new BodyParser(file_get_contents(__DIR__.'/../../Resources/PullRequestBody/feature.txt'));
+        $this->assertSame('#1234', $this->bodyParser->getRelatedTicket());
+    }
+
     public function testRepeatBodParserTestsWithSpaces()
     {
         $this->bodyParser = new BodyParser(file_get_contents(__DIR__.'/../../Resources/PullRequestBody/with_spaces.txt'));

--- a/tests/AppBundle/PullRequests/BodyParserTest.php
+++ b/tests/AppBundle/PullRequests/BodyParserTest.php
@@ -86,7 +86,7 @@ class BodyParserTest extends TestCase
 
     public function testGetTicket()
     {
-        $this->assertSame('http://forge.prestashop.com/browse/TEST-1234', $this->bodyParser->getRelatedTicket());
+        $this->assertSame('#1234', $this->bodyParser->getRelatedTicket());
     }
 
     public function testRepeatBodParserTestsWithSpaces()
@@ -99,5 +99,19 @@ class BodyParserTest extends TestCase
         $this->testGetTicket();
         $this->testIsDeprecated();
         $this->testIsBackwardCompatible();
+    }
+
+    public function testGetEmptyDescription()
+    {
+        $this->bodyParser = new BodyParser(file_get_contents(__DIR__.'/../../Resources/PullRequestBody/missing_description.txt'));
+
+        $this->assertSame($this->bodyParser->getType(), 'bug fix');
+        $this->assertContains($this->bodyParser->getType(), $this->bodyParser->getValidTypes());
+        $this->assertFalse($this->bodyParser->isAFeature());
+        $this->assertFalse($this->bodyParser->isAnImprovement());
+        $this->assertTrue($this->bodyParser->isABugFix());
+        $this->assertFalse($this->bodyParser->isASmallFix());
+        $this->assertFalse($this->bodyParser->isARefacto());
+        $this->assertEmpty($this->bodyParser->getDescription());
     }
 }

--- a/tests/AppBundle/PullRequests/ListenerTest.php
+++ b/tests/AppBundle/PullRequests/ListenerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\AppBundle\PullRequests;
+
+use AppBundle\PullRequests\BodyParser;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\ValidatorBuilder;
+
+class ListenerTest extends TestCase
+{
+
+    private $validator;
+
+    public function setUp()
+    {
+        $this->validator = (new ValidatorBuilder())
+            ->enableAnnotationMapping()
+            ->getValidator();
+    }
+
+    /**
+     * @dataProvider getTests
+     *
+     * @param $description
+     * @param $expected
+     */
+    public function testDescriptions($descriptionFilename, $expected)
+    {
+        $body = file_get_contents(__DIR__.'/../../Resources/PullRequestBody/'.$descriptionFilename);
+        $bodyParser = new BodyParser($body);
+
+        $validations = $this->validator->validate($bodyParser);
+        $this->assertEquals(count($expected), count($validations));
+        foreach ($validations as $validation) {
+            $this->assertContains($validation->getPropertyPath(), $expected);
+        }
+    }
+
+    public function getTests()
+    {
+        return [
+            'Valid description' => [
+                'bug_fix.txt',
+                [],
+            ],
+            'Missing description' => [
+                'missing_description.txt',
+                ['description'],
+            ],
+            'Invalid type' => [
+                'invalid_type.txt',
+                ['type'],
+            ],
+            'Invalid category' => [
+                'invalid_category.txt',
+                ['category'],
+            ],
+            'No related ticked' => [
+                'no_related_ticket.txt',
+                ['relatedTicket'],
+            ],
+        ];
+    }
+}

--- a/tests/AppBundle/PullRequests/ListenerTest.php
+++ b/tests/AppBundle/PullRequests/ListenerTest.php
@@ -8,7 +8,6 @@ use Symfony\Component\Validator\ValidatorBuilder;
 
 class ListenerTest extends TestCase
 {
-
     private $validator;
 
     public function setUp()
@@ -21,7 +20,7 @@ class ListenerTest extends TestCase
     /**
      * @dataProvider getTests
      *
-     * @param $description
+     * @param $descriptionFilename
      * @param $expected
      */
     public function testDescriptions($descriptionFilename, $expected)
@@ -30,7 +29,7 @@ class ListenerTest extends TestCase
         $bodyParser = new BodyParser($body);
 
         $validations = $this->validator->validate($bodyParser);
-        $this->assertEquals(count($expected), count($validations));
+        $this->assertSame(\count($expected), \count($validations));
         foreach ($validations as $validation) {
             $this->assertContains($validation->getPropertyPath(), $expected);
         }

--- a/tests/Resources/PullRequestBody/feature.txt
+++ b/tests/Resources/PullRequestBody/feature.txt
@@ -10,7 +10,7 @@ Please take the time to edit the "Answers" rows with the necessary information:-
 | Category?     | BO
 | BC breaks?    | no
 | Deprecations? | yes
-| Fixed ticket? | http://forge.prestashop.com/browse/TEST-1234
+| Fixed ticket? | #1234
 | How to test?  | To test it, launch unit tests
 
 <!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

--- a/tests/Resources/PullRequestBody/feature.txt
+++ b/tests/Resources/PullRequestBody/feature.txt
@@ -10,7 +10,7 @@ Please take the time to edit the "Answers" rows with the necessary information:-
 | Category?     | BO
 | BC breaks?    | no
 | Deprecations? | yes
-| Fixed ticket? | #1234
+| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/1234
 | How to test?  | To test it, launch unit tests
 
 <!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

--- a/tests/Resources/PullRequestBody/improvement.txt
+++ b/tests/Resources/PullRequestBody/improvement.txt
@@ -10,7 +10,7 @@ Please take the time to edit the "Answers" rows with the necessary information:-
 | Category?     | BO
 | BC breaks?    | no
 | Deprecations? | yes
-| Fixed ticket? | http://forge.prestashop.com/browse/TEST-1234
+| Fixed ticket? | #1234
 | How to test?  | To test it, launch unit tests
 
 <!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

--- a/tests/Resources/PullRequestBody/invalid_category.txt
+++ b/tests/Resources/PullRequestBody/invalid_category.txt
@@ -7,7 +7,7 @@ Please take the time to edit the "Answers" rows with the necessary information:-
 | Branch?       | develop
 | Description?  | Such a great description
 | Type?         |  bug fix
-| Category?     | BO
+| Category?     | AZ
 | BC breaks?    | no
 | Deprecations? | yes
 | Fixed ticket? | #1234

--- a/tests/Resources/PullRequestBody/invalid_type.txt
+++ b/tests/Resources/PullRequestBody/invalid_type.txt
@@ -6,7 +6,7 @@ Please take the time to edit the "Answers" rows with the necessary information:-
 | ------------- | -------------------------------------------------------
 | Branch?       | develop
 | Description?  | Such a great description
-| Type?         |  bug fix
+| Type?         |
 | Category?     | BO
 | BC breaks?    | no
 | Deprecations? | yes

--- a/tests/Resources/PullRequestBody/missing_description.txt
+++ b/tests/Resources/PullRequestBody/missing_description.txt
@@ -5,7 +5,7 @@ Please take the time to edit the "Answers" rows with the necessary information:-
 | Questions     | Answers
 | ------------- | -------------------------------------------------------
 | Branch?       | develop
-| Description?  | Such a great description
+| Description?  |
 | Type?         |  bug fix
 | Category?     | BO
 | BC breaks?    | no

--- a/tests/Resources/PullRequestBody/no_related_ticket.txt
+++ b/tests/Resources/PullRequestBody/no_related_ticket.txt
@@ -10,7 +10,7 @@ Please take the time to edit the "Answers" rows with the necessary information:-
 | Category?     | BO
 | BC breaks?    | no
 | Deprecations? | yes
-| Fixed ticket? | #1234
+| Fixed ticket? |
 | How to test?  | To test it, launch unit tests
 
 <!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

--- a/tests/Resources/PullRequestBody/with_spaces.txt
+++ b/tests/Resources/PullRequestBody/with_spaces.txt
@@ -10,7 +10,7 @@ Please take the time to edit the "Answers" rows with the necessary information:-
 | Category?     | BO
 | BC breaks?    |        no
 | Deprecations? | yes
-| Fixed ticket? |       http://forge.prestashop.com/browse/TEST-1234
+| Fixed ticket? |   This fixes    #1234
 | How to test?  | To test it, launch unit tests
 
 <!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This PR aims to make the "Fixed ticket" field of the PR's description mandatory
| Type?         | new feature
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially fixes https://github.com/PrestaShop/prestashop-retro/issues/67 
| How to test?  | Tests must pass

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
