### PR TITLE
Allows no related ticket when category is TE

### DIFF
--- a/app/Resources/views/markdown/pr_table_errors.md.twig
+++ b/app/Resources/views/markdown/pr_table_errors.md.twig
@@ -10,7 +10,7 @@ Your pull request description seems to be incomplete or malformed:
 Would you mind completing it? This would help us understand how interesting your contribution is, thank you very much!
 
 {% if missingRelatedTicket %}
-Note: it is a good practice to open an issue before submitting a Pull Request as it allows maintainers to verify that the bug is effectively due to a defect in the code (and that it hasn't already been fixed) and to discuss the improvement/feature suggestion before a single line of code is written. Additionally, it may lead the Core Product team to mark that issue as a priority, further attracting the maintainer's attention.
+Note: it is a good practice to open an issue before submitting a Pull Request as it allows maintainers to verify that the bug is effectively due to a defect in the code (and that it hasn't already been fixed) and to discuss the improvement/feature suggestion before a single line of code is written. Additionally, it may lead the Core Product team to mark that issue as a priority, further attracting the maintainer's attention. You can link your Pull Request with an issue by writing "Fixes #12314"
 {% endif %}
 
 (note: this is an automated message, but answering it will reach a real human )

--- a/src/AppBundle/PullRequests/BodyParser.php
+++ b/src/AppBundle/PullRequests/BodyParser.php
@@ -86,7 +86,7 @@ class BodyParser
      */
     public function isTestCategory()
     {
-        return 1 === preg_match('/TE/', $this->getCategory());
+        return 1 === preg_match('/\\bTE\\b/', $this->getCategory());
     }
 
     /**

--- a/src/AppBundle/PullRequests/BodyParser.php
+++ b/src/AppBundle/PullRequests/BodyParser.php
@@ -11,6 +11,8 @@ class BodyParser
 {
     const DEFAULT_PATTERN = '~(?:\|\s+%s\?\s+\|\s+)(%s)\s+~';
 
+    const NOT_TEST_GROUP = 'NotTest';
+
     /**
      * @var string
      */
@@ -82,6 +84,14 @@ class BodyParser
     /**
      * @return bool
      */
+    public function isTestCategory()
+    {
+        return 1 === preg_match('/TE/', $this->getCategory());
+    }
+
+    /**
+     * @return bool
+     */
     public function isBackwardCompatible()
     {
         $regex = sprintf(self::DEFAULT_PATTERN, 'BC breaks', '.+');
@@ -142,7 +152,10 @@ class BodyParser
     }
 
     /**
-     * @Assert\NotBlank(message = "Your pull request does not seem to fix any issue, you might consider [creating one](https://github.com/PrestaShop/PrestaShop/issues/new/choose) (see note below).")
+     * @Assert\NotBlank(
+     *     groups={BodyParser::NOT_TEST_GROUP},
+     *     message = "Your pull request does not seem to fix any issue, you might consider [creating one](https://github.com/PrestaShop/PrestaShop/issues/new/choose) (see note below)."
+     * )
      *
      * @return string
      */

--- a/src/AppBundle/PullRequests/BodyParser.php
+++ b/src/AppBundle/PullRequests/BodyParser.php
@@ -86,7 +86,7 @@ class BodyParser
      */
     public function isTestCategory()
     {
-        return 1 === preg_match('/\\bTE\\b/', $this->getCategory());
+        return 1 === preg_match('/\bTE\b/', $this->getCategory());
     }
 
     /**

--- a/src/AppBundle/PullRequests/Listener.php
+++ b/src/AppBundle/PullRequests/Listener.php
@@ -86,8 +86,19 @@ class Listener
     {
         $bodyParser = new BodyParser($pullRequest->getBody());
 
+        $missingRelatedTicket = false;
         $validationErrors = $this->validator->validate($bodyParser);
-        $missingRelatedTicket = empty($bodyParser->getRelatedTicket());
+        if (!$bodyParser->isTestCategory()) {
+            $notTestValidationErrors = $this->validator->validate(
+                $bodyParser,
+                null,
+                BodyParser::NOT_TEST_GROUP
+            );
+            if ($notTestValidationErrors->count() > 0) {
+                $validationErrors->addAll($notTestValidationErrors);
+                $missingRelatedTicket = true;
+            }
+        }
         if (\count($validationErrors) > 0) {
             $this->commentApi->sendWithTemplate(
                 $pullRequest,

--- a/tests/AppBundle/PullRequests/BodyParserTest.php
+++ b/tests/AppBundle/PullRequests/BodyParserTest.php
@@ -58,6 +58,14 @@ class BodyParserTest extends TestCase
         $this->assertFalse($this->bodyParser->isARefacto());
     }
 
+    public function testGetTestCategory()
+    {
+        $this->bodyParser = new BodyParser(file_get_contents(__DIR__.'/../../Resources/PullRequestBody/TE_category.txt'));
+
+        $this->assertSame('TE', $this->bodyParser->getCategory());
+        $this->assertTrue($this->bodyParser->isTestCategory());
+    }
+
     public function testGetTypeWithoutSpaces()
     {
         $this->bodyParser = new BodyParser(file_get_contents(__DIR__.'/../../Resources/PullRequestBody/improvement.txt'));

--- a/tests/AppBundle/PullRequests/ListenerTest.php
+++ b/tests/AppBundle/PullRequests/ListenerTest.php
@@ -84,6 +84,9 @@ class ListenerTest extends TestCase
         $bodyParser = new BodyParser($body);
 
         $validations = $this->validator->validate($bodyParser);
+        if (!$bodyParser->isTestCategory()) {
+            $validations->addAll($this->validator->validate($bodyParser, null, BodyParser::NOT_TEST_GROUP));
+        }
         $this->assertSame(\count($expected), \count($validations));
         foreach ($validations as $validation) {
             $this->assertContains($validation->getPropertyPath(), $expected);
@@ -144,6 +147,10 @@ class ListenerTest extends TestCase
             'No related ticked' => [
                 'no_related_ticket.txt',
                 ['relatedTicket'],
+            ],
+            'No related ticked TE' => [
+                'no_related_ticket_TE.txt',
+                [],
             ],
         ];
     }

--- a/tests/Resources/PullRequestBody/TE_category.txt
+++ b/tests/Resources/PullRequestBody/TE_category.txt
@@ -1,0 +1,23 @@
+<!-- Thank you for contributing to the PrestaShop project!
+
+Please take the time to edit the "Answers" rows with the necessary information:-->
+
+| Questions     | Answers
+| ------------- | -------------------------------------------------------
+| Branch?       | develop
+| Description?  | Such a great description
+| Type?         |  bug fix
+| Category?     | TE
+| BC breaks?    | no
+| Deprecations? | yes
+| Fixed ticket? | #1234
+| How to test?  | To test it, launch unit tests
+
+<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
+
+#### Important guidelines
+
+* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
+* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
+* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
+

--- a/tests/Resources/PullRequestBody/no_related_ticket_TE.txt
+++ b/tests/Resources/PullRequestBody/no_related_ticket_TE.txt
@@ -1,0 +1,23 @@
+<!-- Thank you for contributing to the PrestaShop project!
+
+Please take the time to edit the "Answers" rows with the necessary information:-->
+
+| Questions     | Answers
+| ------------- | -------------------------------------------------------
+| Branch?       | develop
+| Description?  | Such a great description
+| Type?         |  bug fix
+| Category?     | TE
+| BC breaks?    | no
+| Deprecations? | yes
+| Fixed ticket? |
+| How to test?  | To test it, launch unit tests
+
+<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
+
+#### Important guidelines
+
+* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
+* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
+* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
+


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This PR aims to not consider invalid a PR description with no related ticket if the Category of the PR is TE.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Tests must pass

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
