### PR TITLE
Set max execution time to 3min for new wording detection

### DIFF
--- a/src/AppBundle/PullRequests/Listener.php
+++ b/src/AppBundle/PullRequests/Listener.php
@@ -223,7 +223,7 @@ class Listener
             $validated = $this->getValidatedWordings($existingComment['body']);
         }
 
-        set_time_limit(90);
+        set_time_limit(180);
         $base = $this->githubDownloader->downloadAndExtract($pullRequest, false);
         $head = $this->githubDownloader->downloadAndExtract($pullRequest);
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | For some big PRs, 1.5min wasn't enough to complete the wording detection. Increasing it to 3min should be enough.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
