### PR TITLE
Do not add Waiting for wording when already validated & fix PR validation comment being wrongly removed

### DIFF
--- a/src/AppBundle/Issues/Listener.php
+++ b/src/AppBundle/Issues/Listener.php
@@ -37,6 +37,7 @@ class Listener
         $newStatus = Status::WAITING_FOR_WORDING;
 
         $this->statusApi->addIssueLabel($issueNumber, $newStatus);
+        $this->statusApi->removeIssueLabel($issueNumber, Labels::WORDING_APPROVED);
         $this->log($issueNumber, $newStatus);
 
         return $newStatus;

--- a/src/AppBundle/Issues/StatusApi.php
+++ b/src/AppBundle/Issues/StatusApi.php
@@ -46,6 +46,27 @@ class StatusApi
     }
 
     /**
+     * @param int    $issueNumber The GitHub issue number
+     * @param string $label       A Status::* constant
+     *
+     * @return bool
+     */
+    public function removeIssueLabel($issueNumber, $label)
+    {
+        if (isset(Labels::ALIASES[$label])) {
+            $label = Labels::ALIASES[$label];
+        }
+
+        try {
+            $this->labelsApi->removeIssueLabel($issueNumber, $label);
+        } catch (\Exception $e) {
+            // The Issue didn't have the label already
+        }
+
+        return true;
+    }
+
+    /**
      * @return string
      */
     public function getNeedsReviewUrl()

--- a/src/AppBundle/PullRequests/Labels.php
+++ b/src/AppBundle/PullRequests/Labels.php
@@ -25,6 +25,8 @@ final class Labels
 
     const QA_APPROVED = 'QA ✔️';
 
+    const WORDING_APPROVED = 'Wording ✔️';
+
     // Help to prevent changes in the future
     const ALIASES = [
         'bug fix' => self::BUG,

--- a/src/AppBundle/PullRequests/Listener.php
+++ b/src/AppBundle/PullRequests/Listener.php
@@ -121,6 +121,13 @@ class Listener
         $bodyParser = new BodyParser($pullRequest->getBody());
 
         $bodyErrors = $this->validator->validate($bodyParser);
+        if (!$bodyParser->isTestCategory()) {
+            $bodyErrors->addAll($this->validator->validate(
+                $bodyParser,
+                null,
+                BodyParser::NOT_TEST_GROUP
+            ));
+        }
         if (0 === \count($bodyErrors)) {
             $this->repository->removeCommentsIfExists(
                 $pullRequest,

--- a/tests/AppBundle/Issues/NullStatusApi.php
+++ b/tests/AppBundle/Issues/NullStatusApi.php
@@ -17,6 +17,10 @@ class NullStatusApi extends StatusApi
     {
     }
 
+    public function removeIssueLabel($issueNumber, $label)
+    {
+    }
+
     public function setIssueStatus($issueNumber, $newStatus)
     {
     }

--- a/tests/AppBundle/Issues/StatusApiTest.php
+++ b/tests/AppBundle/Issues/StatusApiTest.php
@@ -88,6 +88,60 @@ class StatusApiTest extends TestCase
         $this->api->addIssueLabel(1234, 'refacto');
     }
 
+    public function testRemoveIssueLabel()
+    {
+        $this->labelsApi->expects($this->once())
+            ->method('removeIssueLabel')
+            ->with(1234, 'Code reviewed');
+
+        $this->api->removeIssueLabel(1234, Status::CODE_REVIEWED);
+    }
+
+    public function testRemoveIssueLabelWithBugAlias()
+    {
+        $this->labelsApi->expects($this->once())
+            ->method('removeIssueLabel')
+            ->with(1234, 'Bug');
+
+        $this->api->removeIssueLabel(1234, 'bug fix');
+    }
+
+    public function testRemoveIssueLabelWithFeatureAlias()
+    {
+        $this->labelsApi->expects($this->once())
+            ->method('removeIssueLabel')
+            ->with(1234, 'Feature');
+
+        $this->api->removeIssueLabel(1234, 'new feature');
+    }
+
+    public function testRemoveIssueLabelWithImprovementAlias()
+    {
+        $this->labelsApi->expects($this->once())
+            ->method('removeIssueLabel')
+            ->with(1234, 'Improvement');
+
+        $this->api->removeIssueLabel(1234, 'improvement');
+    }
+
+    public function testRemoveIssueLabelWithCriticalAlias()
+    {
+        $this->labelsApi->expects($this->once())
+            ->method('removeIssueLabel')
+            ->with(1234, 'Critical');
+
+        $this->api->removeIssueLabel(1234, 'critical');
+    }
+
+    public function testRemoveIssueLabelWithRefactoAlias()
+    {
+        $this->labelsApi->expects($this->once())
+            ->method('removeIssueLabel')
+            ->with(1234, 'Refactoring');
+
+        $this->api->removeIssueLabel(1234, 'refacto');
+    }
+
     public function testGetNeedsReviewUrl()
     {
         $this->assertSame(


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When every translation string have been validated, do not add the label "Waiting for wording". Also, the comment describing what was wrong on the PR description table was removed when editing a PR even if the PR was not linked to an issue. This PR fixes it.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Tests must pass

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
