### PR TITLE
Use same twig version as the PrestaShop project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         "knplabs/github-api": "^2.0",
         "php-http/guzzle6-adapter": "^1.0",
         "prestashop/translationtools-bundle": "^4.0",
-        "prestashop/github-webhook-parser": "^0.1.0"
+        "prestashop/github-webhook-parser": "^0.1.0",
+        "twig/twig": "^1.38.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "30fd02915814e3b548218b794180f7d6",
+    "content-hash": "73486db04516eefff92333cb243b7e07",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -3410,31 +3410,30 @@
         },
         {
             "name": "twig/twig",
-            "version": "v2.12.5",
+            "version": "v1.43.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "18772e0190734944277ee97a02a9a6c6555fcd94"
+                "reference": "2311602f6a208715252febe682fa7c38e56a3373"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/18772e0190734944277ee97a02a9a6c6555fcd94",
-                "reference": "18772e0190734944277ee97a02a9a6c6555fcd94",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/2311602f6a208715252febe682fa7c38e56a3373",
+                "reference": "2311602f6a208715252febe682fa7c38e56a3373",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "symfony/polyfill-ctype": "^1.8",
-                "symfony/polyfill-mbstring": "^1.3"
+                "php": ">=7.1.3",
+                "symfony/polyfill-ctype": "^1.8"
             },
             "require-dev": {
                 "psr/container": "^1.0",
-                "symfony/phpunit-bridge": "^4.4|^5.0"
+                "symfony/phpunit-bridge": "^4.4.9|^5.0.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.12-dev"
+                    "dev-master": "1.43-dev"
                 }
             },
             "autoload": {
@@ -3471,7 +3470,17 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2020-02-11T15:31:23+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-08-05T15:05:05+00:00"
         }
     ],
     "packages-dev": [
@@ -4631,5 +4640,6 @@
         "php": ">=7.1",
         "ext-mbstring": "*"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Because PrestonBot was using a different version of twig than the PrestaShop project, when parsing twig templates an exception could be thrown as some functions are not existing in newer versions of twig. This PR fixes it.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| How to test?  | tests must pass

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
