### PR TITLE
Use Bux fix label instead of Bug

### DIFF
--- a/src/AppBundle/PullRequests/Labels.php
+++ b/src/AppBundle/PullRequests/Labels.php
@@ -15,7 +15,7 @@ final class Labels
 
     const FEATURE = 'Feature';
 
-    const BUG = 'Bug';
+    const BUG = 'Bug fix';
 
     const IMPROVEMENT = 'Improvement';
 

--- a/tests/AppBundle/Issues/StatusApiTest.php
+++ b/tests/AppBundle/Issues/StatusApiTest.php
@@ -47,7 +47,7 @@ class StatusApiTest extends TestCase
     {
         $this->labelsApi->expects($this->once())
             ->method('addIssueLabel')
-            ->with(1234, 'Bug');
+            ->with(1234, 'Bug fix');
 
         $this->api->addIssueLabel(1234, 'bug fix');
     }
@@ -92,7 +92,7 @@ class StatusApiTest extends TestCase
     {
         $this->labelsApi->expects($this->once())
             ->method('removeIssueLabel')
-            ->with(1234, 'Bug');
+            ->with(1234, 'Bug fix');
 
         $this->api->removeIssueLabel(1234, 'bug fix');
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | It make more sense to use label `Bug fix` instead of `Bug` to better reflect the pull request template
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #112
| How to test?      | Tests must pass
| Possible impacts? | /

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
