### PR TITLE
Add PR available when editing PR too

### DIFF
--- a/src/AppBundle/EventSubscriber/PullRequestSubscriber.php
+++ b/src/AppBundle/EventSubscriber/PullRequestSubscriber.php
@@ -53,6 +53,7 @@ class PullRequestSubscriber implements EventSubscriberInterface
                 ['initBranchLabel', 254],
                 ['initPullRequestTypeLabel', 254],
                 ['initBCBreakLabel', 254],
+                ['initPRAvailableLabelInIssue', 254],
             ],
             'pullrequestevent_synchronize' => [
                 ['checkForNewTranslations', 252],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | With #118 , "PR available" label is added only when a PR is created. This PR allows the label to be added also when editing the PR description.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | CI should be green
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
