### PR TITLE
Make related ticket optional when category is ME

### DIFF
--- a/src/AppBundle/PullRequests/BodyParser.php
+++ b/src/AppBundle/PullRequests/BodyParser.php
@@ -11,7 +11,7 @@ class BodyParser
 {
     const DEFAULT_PATTERN = '~(?:\|\s+%s\?\s+\|\s+)(%s)\s+~';
 
-    const NOT_TEST_GROUP = 'NotTest';
+    const ISSUE_NEEDED_GROUP = 'IssueNeeded';
 
     /**
      * @var string
@@ -153,7 +153,7 @@ class BodyParser
 
     /**
      * @Assert\NotBlank(
-     *     groups={BodyParser::NOT_TEST_GROUP},
+     *     groups={BodyParser::ISSUE_NEEDED_GROUP},
      *     message = "Your pull request does not seem to fix any issue, consider [creating one](https://github.com/PrestaShop/PrestaShop/issues/new/choose) (see note below) and linking it by writing `Fixes #1234`."
      * )
      *
@@ -188,6 +188,14 @@ class BodyParser
             'refacto',
             'bug fix',
         ];
+    }
+
+    /**
+     * @return bool
+     */
+    public function isIssueRequired()
+    {
+        return !$this->isTestCategory() && !$this->isMergeCategory();
     }
 
     /**

--- a/src/AppBundle/PullRequests/Listener.php
+++ b/src/AppBundle/PullRequests/Listener.php
@@ -101,14 +101,14 @@ class Listener
 
         $missingRelatedTicket = false;
         $validationErrors = $this->validator->validate($bodyParser);
-        if (!$bodyParser->isTestCategory()) {
-            $notTestValidationErrors = $this->validator->validate(
+        if ($bodyParser->isIssueRequired()) {
+            $issueNeededValidationErrors = $this->validator->validate(
                 $bodyParser,
                 null,
-                BodyParser::NOT_TEST_GROUP
+                BodyParser::ISSUE_NEEDED_GROUP
             );
-            if ($notTestValidationErrors->count() > 0) {
-                $validationErrors->addAll($notTestValidationErrors);
+            if ($issueNeededValidationErrors->count() > 0) {
+                $validationErrors->addAll($issueNeededValidationErrors);
                 $missingRelatedTicket = true;
             }
         }
@@ -133,11 +133,11 @@ class Listener
         $bodyParser = new BodyParser($pullRequest->getBody());
 
         $bodyErrors = $this->validator->validate($bodyParser);
-        if (!$bodyParser->isTestCategory()) {
+        if ($bodyParser->isIssueRequired()) {
             $bodyErrors->addAll($this->validator->validate(
                 $bodyParser,
                 null,
-                BodyParser::NOT_TEST_GROUP
+                BodyParser::ISSUE_NEEDED_GROUP
             ));
         }
         if (0 === \count($bodyErrors)) {

--- a/tests/AppBundle/PullRequests/ListenerTest.php
+++ b/tests/AppBundle/PullRequests/ListenerTest.php
@@ -88,8 +88,8 @@ class ListenerTest extends TestCase
         $bodyParser = new BodyParser($body);
 
         $validations = $this->validator->validate($bodyParser);
-        if (!$bodyParser->isTestCategory()) {
-            $validations->addAll($this->validator->validate($bodyParser, null, BodyParser::NOT_TEST_GROUP));
+        if ($bodyParser->isIssueRequired()) {
+            $validations->addAll($this->validator->validate($bodyParser, null, BodyParser::ISSUE_NEEDED_GROUP));
         }
         $this->assertSame(\count($expected), \count($validations));
         foreach ($validations as $validation) {
@@ -193,6 +193,10 @@ class ListenerTest extends TestCase
             ],
             'No related ticked TE' => [
                 'no_related_ticket_TE.txt',
+                [],
+            ],
+            'No related ticked ME' => [
+                'no_related_ticket_ME.txt',
                 [],
             ],
         ];

--- a/tests/Resources/PullRequestBody/no_related_ticket_ME.txt
+++ b/tests/Resources/PullRequestBody/no_related_ticket_ME.txt
@@ -1,0 +1,23 @@
+<!-- Thank you for contributing to the PrestaShop project!
+
+Please take the time to edit the "Answers" rows with the necessary information:-->
+
+| Questions     | Answers
+| ------------- | -------------------------------------------------------
+| Branch?       | develop
+| Description?  | Such a great description
+| Type?         |  bug fix
+| Category?     | ME
+| BC breaks?    | no
+| Deprecations? | yes
+| Fixed ticket? |
+| How to test?  | To test it, launch unit tests
+
+<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
+
+#### Important guidelines
+
+* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
+* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
+* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
+


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR aims to make the `fixed ticket?` of the table description optional when the category is `ME`
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | CI must be green
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
