### PR TITLE
Improve detection of BC breaks and deprecations

### DIFF
--- a/src/AppBundle/PullRequests/BodyParser.php
+++ b/src/AppBundle/PullRequests/BodyParser.php
@@ -9,7 +9,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 class BodyParser
 {
-    const DEFAULT_PATTERN = '~(?:\|\s+%s\?\s+\|\s+)(%s)\s+~';
+    const DEFAULT_PATTERN = '~(?:\|?\s*%s\?\s*\|\s*)(%s)\s+~';
 
     const ISSUE_NEEDED_GROUP = 'IssueNeeded';
 
@@ -105,7 +105,9 @@ class BodyParser
         $regex = sprintf(self::DEFAULT_PATTERN, 'BC breaks', '.+');
         $bcBreaks = $this->extractWithRegex($regex);
 
-        return 'yes' !== $bcBreaks;
+        return
+            'yes / no' !== $bcBreaks
+            && 'yes' !== substr($bcBreaks, 0, 3);
     }
 
     /**
@@ -116,7 +118,9 @@ class BodyParser
         $regex = sprintf(self::DEFAULT_PATTERN, 'Deprecations', '.+');
         $willDeprecateCode = $this->extractWithRegex($regex);
 
-        return 'no' === $willDeprecateCode;
+        return
+            'yes / no' !== $willDeprecateCode
+            && 'yes' !== substr($willDeprecateCode, 0, 3);
     }
 
     /**

--- a/tests/AppBundle/PullRequests/BodyParserTest.php
+++ b/tests/AppBundle/PullRequests/BodyParserTest.php
@@ -153,13 +153,13 @@ class BodyParserTest extends TestCase
      *
      * @return void
      */
-    public function testBackwardCompatible(string $file, bool $isBackwardCompatible)
+    public function testBackwardCompatible(string $file, bool $isBackwardCompatible): void
     {
         $bodyParser = new BodyParser(file_get_contents($file));
         $this->assertSame($isBackwardCompatible, $bodyParser->isBackwardCompatible());
     }
 
-    public function provideBackwardCompatibleTests()
+    public function provideBackwardCompatibleTests(): array
     {
         $base = __DIR__.'/../../Resources/PullRequestBody/';
 
@@ -187,13 +187,13 @@ class BodyParserTest extends TestCase
      *
      * @return void
      */
-    public function testWillDeprecateCode(string $file, bool $willDeprecateCode)
+    public function testWillDeprecateCode(string $file, bool $willDeprecateCode): void
     {
         $bodyParser = new BodyParser(file_get_contents($file));
         $this->assertSame($willDeprecateCode, $bodyParser->willDeprecateCode());
     }
 
-    public function provideWillDeprecateCodeTests()
+    public function provideWillDeprecateCodeTests(): array
     {
         $base = __DIR__.'/../../Resources/PullRequestBody/';
 

--- a/tests/AppBundle/PullRequests/BodyParserTest.php
+++ b/tests/AppBundle/PullRequests/BodyParserTest.php
@@ -144,4 +144,72 @@ class BodyParserTest extends TestCase
         $this->assertFalse($this->bodyParser->isARefacto());
         $this->assertEmpty($this->bodyParser->getDescription());
     }
+
+    /**
+     * @dataProvider provideBackwardCompatibleTests
+     *
+     * @param string $file
+     * @param bool   $isBackwardCompatible
+     *
+     * @return void
+     */
+    public function testBackwardCompatible(string $file, bool $isBackwardCompatible)
+    {
+        $bodyParser = new BodyParser(file_get_contents($file));
+        $this->assertSame($isBackwardCompatible, $bodyParser->isBackwardCompatible());
+    }
+
+    public function provideBackwardCompatibleTests()
+    {
+        $base = __DIR__.'/../../Resources/PullRequestBody/';
+
+        return [
+            'Backward compatible' => [
+                $base.'bug_fix.txt',
+                true,
+            ],
+            'Backward incompatible' => [
+                $base.'bug_fix_bc_break.txt',
+                false,
+            ],
+            'Backward incompatible with comments' => [
+                $base.'bug_fix_bc_break_alt.txt',
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideWillDeprecateCodeTests
+     *
+     * @param string $file
+     * @param bool   $willDeprecateCode
+     *
+     * @return void
+     */
+    public function testWillDeprecateCode(string $file, bool $willDeprecateCode)
+    {
+        $bodyParser = new BodyParser(file_get_contents($file));
+        $this->assertSame($willDeprecateCode, $bodyParser->willDeprecateCode());
+    }
+
+    public function provideWillDeprecateCodeTests()
+    {
+        $base = __DIR__.'/../../Resources/PullRequestBody/';
+
+        return [
+            'No deprecates' => [
+                $base.'bug_fix_no_deprecate.txt',
+                true,
+            ],
+            'Deprecates' => [
+                $base.'bug_fix.txt',
+                false,
+            ],
+            'Deprecates with comments' => [
+                $base.'bug_fix_deprecate_alt.txt',
+                false,
+            ],
+        ];
+    }
 }

--- a/tests/Resources/PullRequestBody/bug_fix_bc_break.txt
+++ b/tests/Resources/PullRequestBody/bug_fix_bc_break.txt
@@ -1,0 +1,23 @@
+<!-- Thank you for contributing to the PrestaShop project!
+
+Please take the time to edit the "Answers" rows with the necessary information:-->
+
+| Questions     | Answers
+| ------------- | -------------------------------------------------------
+| Branch?       | develop
+| Description?  | Such a great description
+| Type?         |  bug fix
+| Category?     | BO
+| BC breaks?    | yes
+| Deprecations? | yes
+| Fixed ticket? | #1234
+| How to test?  | To test it, launch unit tests
+
+<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
+
+#### Important guidelines
+
+* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
+* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
+* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
+

--- a/tests/Resources/PullRequestBody/bug_fix_bc_break_alt.txt
+++ b/tests/Resources/PullRequestBody/bug_fix_bc_break_alt.txt
@@ -1,0 +1,23 @@
+<!-- Thank you for contributing to the PrestaShop project!
+
+Please take the time to edit the "Answers" rows with the necessary information:-->
+
+| Questions     | Answers
+| ------------- | -------------------------------------------------------
+| Branch?       | develop
+| Description?  | Such a great description
+| Type?         |  bug fix
+| Category?     | BO
+| BC breaks?    |  yes - something was broken
+| Deprecations? | yes
+| Fixed ticket? | #1234
+| How to test?  | To test it, launch unit tests
+
+<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
+
+#### Important guidelines
+
+* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
+* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
+* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
+

--- a/tests/Resources/PullRequestBody/bug_fix_deprecate_alt.txt
+++ b/tests/Resources/PullRequestBody/bug_fix_deprecate_alt.txt
@@ -1,0 +1,23 @@
+<!-- Thank you for contributing to the PrestaShop project!
+
+Please take the time to edit the "Answers" rows with the necessary information:-->
+
+| Questions     | Answers
+| ------------- | -------------------------------------------------------
+| Branch?       | develop
+| Description?  | Such a great description
+| Type?         |  bug fix
+| Category?     | BO
+| BC breaks?    | yes
+| Deprecations? | yes - blach blah
+| Fixed ticket? | #1234
+| How to test?  | To test it, launch unit tests
+
+<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
+
+#### Important guidelines
+
+* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
+* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
+* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
+

--- a/tests/Resources/PullRequestBody/bug_fix_no_deprecate.txt
+++ b/tests/Resources/PullRequestBody/bug_fix_no_deprecate.txt
@@ -1,0 +1,23 @@
+<!-- Thank you for contributing to the PrestaShop project!
+
+Please take the time to edit the "Answers" rows with the necessary information:-->
+
+| Questions     | Answers
+| ------------- | -------------------------------------------------------
+| Branch?       | develop
+| Description?  | Such a great description
+| Type?         |  bug fix
+| Category?     | BO
+| BC breaks?    | yes
+| Deprecations? | no
+| Fixed ticket? | #1234
+| How to test?  | To test it, launch unit tests
+
+<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
+
+#### Important guidelines
+
+* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
+* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
+* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
+


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Improve detection of BC breaks and deprecations when used together with comments and not just "yes"
| Type?             | improvement

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
